### PR TITLE
Create tiles_within_range function and fix neigbors

### DIFF
--- a/crates/src/map/hex/hex.cairo
+++ b/crates/src/map/hex/hex.cairo
@@ -1,10 +1,17 @@
+use core::clone::Clone;
+use core::traits::Into;
+use core::box::BoxTrait;
+use core::option::OptionTrait;
+use core::array::ArrayTrait;
 use origami::map::hex::{types::{HexTile, Direction, DirectionIntoFelt252}};
 
 trait IHexTile {
     fn new(col: u32, row: u32) -> HexTile;
     fn neighbor(self: HexTile, direction: Direction) -> HexTile;
+    fn neighbor_even_y(self: HexTile, direction: Direction) -> HexTile;
     fn neighbors(self: HexTile) -> Array<HexTile>;
     fn is_neighbor(self: HexTile, other: HexTile) -> bool;
+    fn tiles_within_range(self: HexTile, range: u32) -> Array<HexTile>;
 }
 
 impl ImplHexTile of IHexTile {
@@ -23,15 +30,36 @@ impl ImplHexTile of IHexTile {
         }
     }
 
+    fn neighbor_even_y(self: HexTile, direction: Direction) -> HexTile {
+        match direction {
+            Direction::East(()) => HexTile { col: self.col + 1, row: self.row },
+            Direction::NorthEast(()) => HexTile { col: self.col, row: self.row + 1 },
+            Direction::NorthWest(()) => HexTile { col: self.col - 1, row: self.row + 1 },
+            Direction::West(()) => HexTile { col: self.col - 1, row: self.row },
+            Direction::SouthWest(()) => HexTile { col: self.col - 1, row: self.row - 1 },
+            Direction::SouthEast(()) => HexTile { col: self.col, row: self.row - 1 },
+        }
+    }
+
     fn neighbors(self: HexTile) -> Array<HexTile> {
-        array![
+        if (self.row % 2 == 0) {
+            return array![
+                self.neighbor_even_y(Direction::East(())),
+                self.neighbor_even_y(Direction::NorthEast(())),
+                self.neighbor_even_y(Direction::NorthWest(())),
+                self.neighbor_even_y(Direction::West(())),
+                self.neighbor_even_y(Direction::SouthWest(())),
+                self.neighbor_even_y(Direction::SouthEast(()))
+            ];
+        }
+        return array![
             self.neighbor(Direction::East(())),
             self.neighbor(Direction::NorthEast(())),
             self.neighbor(Direction::NorthWest(())),
             self.neighbor(Direction::West(())),
             self.neighbor(Direction::SouthWest(())),
             self.neighbor(Direction::SouthEast(()))
-        ]
+        ];
     }
 
     fn is_neighbor(self: HexTile, other: HexTile) -> bool {
@@ -50,6 +78,54 @@ impl ImplHexTile of IHexTile {
                 }
             };
         }
+    }
+
+    fn tiles_within_range(self: HexTile, range: u32) -> Array<HexTile> {
+        let mut queue = array![self];
+        let mut visited = array![self];
+        let mut moves = 0;
+
+        loop {
+            if moves == range {
+                break;
+            }
+            let mut next_queue = array![];
+            loop {
+                if queue.len() == 0 {
+                    break;
+                }
+                let tile = queue.pop_front().unwrap();
+                let mut neighbors = tile.neighbors();
+
+                loop {
+                    if neighbors.len() == 0 {
+                        break;
+                    }
+                    let neighbor = neighbors.pop_front().unwrap();
+                    let mut is_visited = false;
+                    let mut index = 0;
+                    let visited_span = visited.span();
+
+                    loop {
+                        if index == visited_span.len() || is_visited == true {
+                            break;
+                        }
+                        let curr = *visited_span.at(index);
+                        if (curr.col == neighbor.col && curr.row == neighbor.row) {
+                            is_visited = true;
+                        }
+                        index = index + 1;
+                    };
+                    if !is_visited {
+                        next_queue.append(neighbor);
+                        visited.append(neighbor);
+                    }
+                };
+            };
+            queue = next_queue.clone();
+            moves = moves + 1;
+        };
+        return visited;
     }
 }
 
@@ -130,5 +206,19 @@ mod tests {
             hex_tile.is_neighbor(HexTile { col: hex_tile.col + 1, row: hex_tile.row - 1 }),
             'south east'
         );
+    }
+
+    #[test]
+    #[available_gas(5012300000000000000)]
+    fn test_tiles_within_range() {
+        let mut hex_tile = ImplHexTile::new(5, 5);
+
+        let tiles_range_one = hex_tile.tiles_within_range(1);
+        let tiles_range_two = hex_tile.tiles_within_range(2);
+        let tiles_range_three = hex_tile.tiles_within_range(3);
+
+        assert(tiles_range_one.len() == 7, 'should be 7');
+        assert(tiles_range_two.len() == 19, 'should be 19');
+        assert(tiles_range_three.len() == 37, 'should be 37');
     }
 }


### PR DESCRIPTION
1. tiles_within_range gets all of the tiles within X moves of a tile. In a bit of a crunch to ship hegemony so I have not written a test yet
2. Neighbors for a tile depend on the row(y value) that a hex has


