### PR TITLE
fix: ensure warning about abi embed are removed

### DIFF
--- a/token/src/components/tests/mocks/erc20/erc20_balance_mock.cairo
+++ b/token/src/components/tests/mocks/erc20/erc20_balance_mock.cairo
@@ -26,6 +26,10 @@ trait IERC20BalanceMock<TState> {
     fn initializer(ref self: TState, initial_supply: u256, recipient: ContractAddress,);
 }
 
+#[starknet::interface]
+trait IERC20BalanceMockInit<TState> {
+    fn initializer(ref self: TState, initial_supply: u256, recipient: ContractAddress,);
+}
 
 #[dojo::contract]
 mod erc20_balance_mock {
@@ -69,8 +73,7 @@ mod erc20_balance_mock {
     }
 
     #[abi(embed_v0)]
-    #[generate_trait]
-    impl InitializerImpl of InitializerTrait {
+    impl InitializerImpl of super::IERC20BalanceMockInit<ContractState> {
         fn initializer(ref self: ContractState, initial_supply: u256, recipient: ContractAddress,) {
             // set balance for recipient
             self.erc20_balance.update_balance(recipient, 0, initial_supply);

--- a/token/src/components/tests/mocks/erc20/erc20_bridgeable_mock.cairo
+++ b/token/src/components/tests/mocks/erc20/erc20_bridgeable_mock.cairo
@@ -1,3 +1,17 @@
+use starknet::ContractAddress;
+
+#[starknet::interface]
+trait IERC20BridgeableMockInit<TState> {
+    fn initializer(
+        ref self: TState,
+        name: felt252,
+        symbol: felt252,
+        initial_supply: u256,
+        recipient: ContractAddress,
+        l2_bridge_address: ContractAddress,
+    );
+}
+
 #[dojo::contract]
 mod erc20_bridgeable_mock {
     use starknet::ContractAddress;
@@ -91,8 +105,7 @@ mod erc20_bridgeable_mock {
     //
 
     #[abi(embed_v0)]
-    #[generate_trait]
-    impl ERC20InitializerImpl of ERC20InitializerTrait {
+    impl ERC20InitializerImpl of super::IERC20BridgeableMockInit<ContractState> {
         fn initializer(
             ref self: ContractState,
             name: felt252,

--- a/token/src/presets/erc20/bridgeable.cairo
+++ b/token/src/presets/erc20/bridgeable.cairo
@@ -65,6 +65,22 @@ trait IERC20BridgeablePreset<TState> {
 }
 
 
+///
+/// Interface required to remove compiler warnings and future
+/// deprecation.
+///
+#[starknet::interface]
+trait IERC20BridgeableInitializer<TState> {
+    fn initializer(
+        ref self: TState,
+        name: felt252,
+        symbol: felt252,
+        initial_supply: u256,
+        recipient: ContractAddress,
+        l2_bridge_address: ContractAddress
+    );
+}
+
 #[dojo::contract]
 mod ERC20Bridgeable {
     use token::erc20::interface;
@@ -186,8 +202,7 @@ mod ERC20Bridgeable {
     //
 
     #[abi(embed_v0)]
-    #[generate_trait]
-    impl ERC20InitializerImpl of ERC20InitializerTrait {
+    impl ERC20InitializerImpl of super::IERC20BridgeableInitializer<ContractState> {
         fn initializer(
             ref self: ContractState,
             name: felt252,


### PR DESCRIPTION
## Introduced changes

Working on compiler 2.5.3 with new dojo version, and some warning about future deprecated features were emitted. This PR aims at fixing thos.

Basically we can't use `[#abi(embed_v0)]` if it's not over a `#[starknet::interface]`.

## Checklist

<!-- Make sure all of these are complete -->

- [X] Linked relevant issue
- [X] Updated relevant documentation
- [X] Added relevant tests
- [ ] Add a dedicated CI job for new examples
- [X] Performed self-review of the code

PS: this will not run in the CI for now. First the new dojo branch must be in use.