### PR TITLE
update_to_v0.6.0.alpha-13

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,8 @@ name: Origami CI
 on: [push, pull_request]
 
 env:
-  DOJO_VERSION: v0.6.0-alpha.6
-  SCARB_VERSION: v2.5.4
+  DOJO_VERSION: v0.6.0-alpha.10
+  SCARB_VERSION: v2.6.4
 
 jobs:
   check:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: Origami CI
 on: [push, pull_request]
 
 env:
-  DOJO_VERSION: v0.6.0-alpha.10
+  DOJO_VERSION: v0.6.0-alpha.13
   SCARB_VERSION: v2.6.4
 
 jobs:

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 .vscode
 target
+abis
+manifests

--- a/Scarb.lock
+++ b/Scarb.lock
@@ -11,12 +11,12 @@ dependencies = [
 [[package]]
 name = "cubit"
 version = "1.3.0"
-source = "git+https://github.com/notV4l/cubit.git?rev=5aa99005#5aa99005475012a04421e85c8fa3dc77f53c8ca3"
+source = "git+https://github.com/influenceth/cubit.git#9402f710716b12c21cd1e481c57c54edaf5bb4b1"
 
 [[package]]
 name = "dojo"
 version = "0.5.1"
-source = "git+https://github.com/dojoengine/dojo?tag=v0.6.0-alpha.6#cfdd17029222b8baacc4efc06d9fe945458686f6"
+source = "git+https://github.com/dojoengine/dojo?tag=v0.6.0-alpha.10#c0da5b447185c8c191d9b0e337e00e7843a67d94"
 dependencies = [
  "dojo_plugin",
 ]
@@ -45,7 +45,7 @@ dependencies = [
 
 [[package]]
 name = "origami"
-version = "0.6.0-alpha.6"
+version = "0.6.0-alpha.10"
 dependencies = [
  "cubit",
  "dojo",

--- a/Scarb.lock
+++ b/Scarb.lock
@@ -16,7 +16,7 @@ source = "git+https://github.com/influenceth/cubit.git#9402f710716b12c21cd1e481c
 [[package]]
 name = "dojo"
 version = "0.5.1"
-source = "git+https://github.com/dojoengine/dojo?tag=v0.6.0-alpha.10#c0da5b447185c8c191d9b0e337e00e7843a67d94"
+source = "git+https://github.com/dojoengine/dojo?tag=v0.6.0-alpha.13#5bdcfdff82c7a01443bf603047f4bfe00d210ed6"
 dependencies = [
  "dojo_plugin",
 ]
@@ -45,7 +45,7 @@ dependencies = [
 
 [[package]]
 name = "origami"
-version = "0.6.0-alpha.10"
+version = "0.6.0-alpha.13"
 dependencies = [
  "cubit",
  "dojo",

--- a/Scarb.toml
+++ b/Scarb.toml
@@ -9,13 +9,13 @@ members = [
 ]
 
 [workspace.package]
-version = "0.6.0-alpha.10"
+version = "0.6.0-alpha.13"
 description = "Community-maintained libraries for Cairo"
 homepage = "https://github.com/dojoengine/origami"
 authors = ["bal7hazar@proton.me"]
 
 [workspace.dependencies]
 cubit = { git = "https://github.com/influenceth/cubit.git" }
-dojo = { git = "https://github.com/dojoengine/dojo", tag = "v0.6.0-alpha.10" }
+dojo = { git = "https://github.com/dojoengine/dojo", tag = "v0.6.0-alpha.13" }
 origami = { path = "crates" }
 token = { path = "token" }

--- a/Scarb.toml
+++ b/Scarb.toml
@@ -9,14 +9,13 @@ members = [
 ]
 
 [workspace.package]
-version = "0.6.0-alpha.6"
+version = "0.6.0-alpha.10"
 description = "Community-maintained libraries for Cairo"
 homepage = "https://github.com/dojoengine/origami"
 authors = ["bal7hazar@proton.me"]
 
 [workspace.dependencies]
-# cubit = { git = "https://github.com/influenceth/cubit.git" }
-cubit = { git = "https://github.com/notV4l/cubit.git", rev = "5aa99005" }
-dojo = { git = "https://github.com/dojoengine/dojo", tag = "v0.6.0-alpha.6" }
+cubit = { git = "https://github.com/influenceth/cubit.git" }
+dojo = { git = "https://github.com/dojoengine/dojo", tag = "v0.6.0-alpha.10" }
 origami = { path = "crates" }
 token = { path = "token" }

--- a/examples/bridge/sn/src/dojo_bridge.cairo
+++ b/examples/bridge/sn/src/dojo_bridge.cairo
@@ -132,7 +132,9 @@ mod dojo_bridge {
         token_dispatcher.mint(recipient, amount);
 
         let event = DepositHandled { recipient, amount };
-        self.emit_event(event);
+
+        self.emit(event.clone());
+        emit!(self.world(), (Event::DepositHandled(event)));
     }
 
     //
@@ -162,7 +164,9 @@ mod dojo_bridge {
             starknet::syscalls::send_message_to_l1_syscall(data.l1_bridge, message.span());
 
             let event = WithdrawalInitiated { sender: caller, recipient: l1_recipient, amount };
-            self.emit_event(event);
+           
+            self.emit(event.clone());
+            emit!(self.world(), (Event::WithdrawalInitiated(event)));
         }
 
         fn get_l1_bridge(self: @ContractState) -> felt252 {
@@ -181,12 +185,6 @@ mod dojo_bridge {
             get!(self.world(), get_contract_address(), (DojoBridgeModel))
         }
 
-        fn emit_event<S, +traits::Into<S, Event>, +Drop<S>, +Clone<S>>(
-            ref self: ContractState, event: S
-        ) {
-            self.emit(event.clone());
-            emit!(self.world(), event);
-        }
     }
 }
 

--- a/examples/hex_map/src/actions.cairo
+++ b/examples/hex_map/src/actions.cairo
@@ -88,7 +88,7 @@ mod actions {
             set!(world, (next));
 
             // Emit an event to the world to notify about the player's move.
-            emit!(world, Moved { player, direction });
+            emit!(world, (Event::Moved(Moved { player, direction })));
         }
     }
 }

--- a/token/.gitignore
+++ b/token/.gitignore
@@ -1,1 +1,3 @@
 target
+abis
+manifests

--- a/token/src/components/token/erc20/erc20_allowance.cairo
+++ b/token/src/components/token/erc20/erc20_allowance.cairo
@@ -114,7 +114,9 @@ mod erc20_allowance_component {
             let approval_event = Approval {
                 owner: allowance.owner, spender: allowance.spender, value: allowance.amount
             };
-            self.emit_event(approval_event);
+
+            self.emit(approval_event.clone());
+            emit!(self.get_contract().world(), (Event::Approval(approval_event)));
         }
 
         // use in transfer_from
@@ -127,13 +129,6 @@ mod erc20_allowance_component {
             let mut allowance = self.get_allowance(owner, spender);
             allowance.amount = allowance.amount - amount;
             self.set_allowance(allowance);
-        }
-
-        fn emit_event<S, +traits::Into<S, Event>, +Drop<S>, +Clone<S>>(
-            ref self: ComponentState<TContractState>, event: S
-        ) {
-            self.emit(event.clone());
-            emit!(self.get_contract().world(), event);
         }
     }
 }

--- a/token/src/components/token/erc20/erc20_balance.cairo
+++ b/token/src/components/token/erc20/erc20_balance.cairo
@@ -170,14 +170,9 @@ mod erc20_balance_component {
             self.update_balance(recipient, 0, amount);
 
             let transfer_event = Transfer { from: sender, to: recipient, value: amount };
-            self.emit_event(transfer_event);
-        }
 
-        fn emit_event<S, +traits::Into<S, Event>, +Drop<S>, +Clone<S>>(
-            ref self: ComponentState<TContractState>, event: S
-        ) {
-            self.emit(event.clone());
-            emit!(self.get_contract().world(), event);
+            self.emit(transfer_event.clone());
+            emit!(self.get_contract().world(), (Event::Transfer(transfer_event)));
         }
     }
 }

--- a/token/src/components/token/erc20/erc20_burnable.cairo
+++ b/token/src/components/token/erc20/erc20_burnable.cairo
@@ -15,6 +15,7 @@ mod erc20_burnable_component {
     use erc20_balance_comp::InternalImpl as ERC20BalanceInternal;
     use erc20_metadata_comp::InternalImpl as ERC20MetadataInternal;
 
+
     #[storage]
     struct Storage {}
 
@@ -43,7 +44,11 @@ mod erc20_burnable_component {
             let transfer_event = erc20_balance_comp::Transfer {
                 from: account, to: Zeroable::zero(), value: amount
             };
-            erc20_balance.emit_event(transfer_event);
+
+            erc20_balance.emit(transfer_event.clone());
+            emit!(
+                self.get_contract().world(), (erc20_balance_comp::Event::Transfer(transfer_event))
+            );
         }
     }
 }

--- a/token/src/components/token/erc20/erc20_mintable.cairo
+++ b/token/src/components/token/erc20/erc20_mintable.cairo
@@ -46,7 +46,11 @@ mod erc20_mintable_component {
             let transfer_event = erc20_balance_comp::Transfer {
                 from: Zeroable::zero(), to: recipient, value: amount
             };
-            erc20_balance.emit_event(transfer_event);
+
+            erc20_balance.emit(transfer_event.clone());
+            emit!(
+                self.get_contract().world(), (erc20_balance_comp::Event::Transfer(transfer_event))
+            );
         }
     }
 }

--- a/token/src/erc1155/erc1155.cairo
+++ b/token/src/erc1155/erc1155.cairo
@@ -242,7 +242,11 @@ mod ERC1155 {
                 self.world(),
                 ERC1155OperatorApproval { token: get_contract_address(), owner, operator, approved }
             );
-            self.emit_event(ApprovalForAll { owner, operator, approved });
+
+            let approval_for_all_event = ApprovalForAll { owner, operator, approved };
+
+            self.emit(approval_for_all_event.clone());
+            emit!(self.world(), (Event::ApprovalForAll(approval_for_all_event)));
         }
 
         fn set_balance(ref self: ContractState, account: ContractAddress, id: u256, amount: u256) {
@@ -260,15 +264,6 @@ mod ERC1155 {
         ) {
             self.set_balance(from, id, self.get_balance(from, id).amount - amount);
             self.set_balance(to, id, self.get_balance(to, id).amount + amount);
-        }
-
-        fn emit_event<
-            S, impl IntoImp: traits::Into<S, Event>, impl SDrop: Drop<S>, impl SClone: Clone<S>
-        >(
-            ref self: ContractState, event: S
-        ) {
-            self.emit(event.clone());
-            emit!(self.world(), event);
         }
     }
 
@@ -305,10 +300,12 @@ mod ERC1155 {
         ) {
             self.update_balances(from, to, id, amount);
 
-            self
-                .emit_event(
-                    TransferSingle { operator: get_caller_address(), from, to, id, value: amount }
-                );
+            let transfer_single_event = TransferSingle {
+                operator: get_caller_address(), from, to, id, value: amount
+            };
+
+            self.emit(transfer_single_event.clone());
+            emit!(self.world(), (Event::TransferSingle(transfer_single_event)));
         }
 
         fn _safe_batch_transfer_from(
@@ -333,10 +330,12 @@ mod ERC1155 {
                 self.update_balances(from, to, id, amount);
             };
 
-            self
-                .emit_event(
-                    TransferBatch { operator: get_caller_address(), from, to, ids, values: amounts }
-                );
+            let transfer_batch_event = TransferBatch {
+                operator: get_caller_address(), from, to, ids, values: amounts
+            };
+
+            self.emit(transfer_batch_event.clone());
+            emit!(self.world(), (Event::TransferBatch(transfer_batch_event)));
         }
 
         fn _mint(ref self: ContractState, to: ContractAddress, id: u256, amount: u256) {
@@ -344,16 +343,12 @@ mod ERC1155 {
 
             self.set_balance(to, id, self.get_balance(to, id).amount + amount);
 
-            self
-                .emit_event(
-                    TransferSingle {
-                        operator: get_caller_address(),
-                        from: Zeroable::zero(),
-                        to,
-                        id,
-                        value: amount
-                    }
-                );
+            let transfer_single_event = TransferSingle {
+                operator: get_caller_address(), from: Zeroable::zero(), to, id, value: amount
+            };
+
+            self.emit(transfer_single_event.clone());
+            emit!(self.world(), (Event::TransferSingle(transfer_single_event)));
         }
 
         fn _burn(ref self: ContractState, id: u256, amount: u256) {
@@ -362,16 +357,16 @@ mod ERC1155 {
 
             self.set_balance(caller, id, self.get_balance(caller, id).amount - amount);
 
-            self
-                .emit_event(
-                    TransferSingle {
-                        operator: get_caller_address(),
-                        from: caller,
-                        to: Zeroable::zero(),
-                        id,
-                        value: amount
-                    }
-                );
+            let transfer_single_event = TransferSingle {
+                operator: get_caller_address(),
+                from: caller,
+                to: Zeroable::zero(),
+                id,
+                value: amount
+            };
+
+            self.emit(transfer_single_event.clone());
+            emit!(self.world(), (Event::TransferSingle(transfer_single_event)));
         }
 
         fn _safe_mint(

--- a/token/src/erc20/erc20.cairo
+++ b/token/src/erc20/erc20.cairo
@@ -190,21 +190,13 @@ mod ERC20 {
             assert(!allowance.owner.is_zero(), Errors::APPROVE_FROM_ZERO);
             assert(!allowance.spender.is_zero(), Errors::APPROVE_TO_ZERO);
             set!(self.world(), (allowance));
-            self
-                .emit_event(
-                    Approval {
-                        owner: allowance.owner, spender: allowance.spender, value: allowance.amount
-                    }
-                );
-        }
 
-        fn emit_event<
-            S, impl IntoImp: traits::Into<S, Event>, impl SDrop: Drop<S>, impl SCopy: Copy<S>
-        >(
-            ref self: ContractState, event: S
-        ) {
-            self.emit(event);
-            emit!(self.world(), event);
+            let approval_event = Approval {
+                owner: allowance.owner, spender: allowance.spender, value: allowance.amount
+            };
+
+            self.emit(approval_event.clone());
+            emit!(self.world(), (Event::Approval(approval_event)));
         }
     }
 
@@ -219,14 +211,22 @@ mod ERC20 {
             assert(!recipient.is_zero(), Errors::MINT_TO_ZERO);
             self.update_total_supply(0, amount);
             self.update_balance(recipient, 0, amount);
-            self.emit_event(Transfer { from: Zeroable::zero(), to: recipient, value: amount });
+
+            let transfer_event = Transfer { from: Zeroable::zero(), to: recipient, value: amount };
+
+            self.emit(transfer_event.clone());
+            emit!(self.world(), (Event::Transfer(transfer_event)));
         }
 
         fn _burn(ref self: ContractState, account: ContractAddress, amount: u256) {
             assert(!account.is_zero(), Errors::BURN_FROM_ZERO);
             self.update_total_supply(amount, 0);
             self.update_balance(account, amount, 0);
-            self.emit_event(Transfer { from: account, to: Zeroable::zero(), value: amount });
+
+            let transfer_event = Transfer { from: account, to: Zeroable::zero(), value: amount };
+
+            self.emit(transfer_event.clone());
+            emit!(self.world(), (Event::Transfer(transfer_event)));
         }
 
         fn _approve(
@@ -248,7 +248,11 @@ mod ERC20 {
             assert(!recipient.is_zero(), Errors::TRANSFER_TO_ZERO);
             self.update_balance(sender, amount, 0);
             self.update_balance(recipient, 0, amount);
-            self.emit_event(Transfer { from: sender, to: recipient, value: amount });
+
+            let transfer_event = Transfer { from: sender, to: recipient, value: amount };
+
+            self.emit(transfer_event.clone());
+            emit!(self.world(), (Event::Transfer(transfer_event)));
         }
 
         fn _spend_allowance(

--- a/token/src/erc721/erc721.cairo
+++ b/token/src/erc721/erc721.cairo
@@ -250,7 +250,10 @@ mod ERC721 {
                 ERC721TokenApproval { token: get_contract_address(), token_id, address: to, }
             );
             if emit {
-                self.emit_event(Approval { owner, approved: to, token_id });
+                let approval_event = Approval { owner, approved: to, token_id };
+
+                self.emit(approval_event.clone());
+                emit!(self.world(), (Event::Approval(approval_event)));
             }
         }
 
@@ -264,7 +267,11 @@ mod ERC721 {
                 self.world(),
                 ERC721OperatorApproval { token: get_contract_address(), owner, operator, approved }
             );
-            self.emit_event(ApprovalForAll { owner, operator, approved });
+
+            let approval_for_all_event = ApprovalForAll { owner, operator, approved };
+
+            self.emit(approval_for_all_event.clone());
+            emit!(self.world(), (Event::ApprovalForAll(approval_for_all_event)));
         }
 
         fn set_balance(ref self: ContractState, account: ContractAddress, amount: u256) {
@@ -273,15 +280,6 @@ mod ERC721 {
 
         fn set_owner(ref self: ContractState, token_id: u256, address: ContractAddress) {
             set!(self.world(), ERC721Owner { token: get_contract_address(), token_id, address });
-        }
-
-        fn emit_event<
-            S, impl IntoImp: traits::Into<S, Event>, impl SDrop: Drop<S>, impl SCopy: Copy<S>
-        >(
-            ref self: ContractState, event: S
-        ) {
-            self.emit(event);
-            emit!(self.world(), event);
         }
     }
 
@@ -339,7 +337,10 @@ mod ERC721 {
             self.set_balance(to, self.get_balance(to).amount + 1);
             self.set_owner(token_id, to);
 
-            self.emit_event(Transfer { from: Zeroable::zero(), to, token_id });
+            let transfer_event = Transfer { from: Zeroable::zero(), to, token_id };
+
+            self.emit(transfer_event.clone());
+            emit!(self.world(), (Event::Transfer(transfer_event)));
         }
 
         fn _transfer(
@@ -356,7 +357,10 @@ mod ERC721 {
             self.set_balance(to, self.get_balance(to).amount + 1);
             self.set_owner(token_id, to);
 
-            self.emit_event(Transfer { from, to, token_id });
+            let transfer_event = Transfer { from, to, token_id };
+
+            self.emit(transfer_event.clone());
+            emit!(self.world(), (Event::Transfer(transfer_event)));
         }
 
         fn _burn(ref self: ContractState, token_id: u256) {
@@ -368,7 +372,10 @@ mod ERC721 {
             self.set_balance(owner, self.get_balance(owner).amount - 1);
             self.set_owner(token_id, Zeroable::zero());
 
-            self.emit_event(Transfer { from: owner, to: Zeroable::zero(), token_id });
+            let transfer_event = Transfer { from: owner, to: Zeroable::zero(), token_id };
+
+            self.emit(transfer_event.clone());
+            emit!(self.world(), (Event::Transfer(transfer_event)));
         }
 
         fn _safe_mint(

--- a/token/src/presets/erc20/bridgeable.cairo
+++ b/token/src/presets/erc20/bridgeable.cairo
@@ -73,7 +73,6 @@ trait IERC20BridgeableInitializer<TState> {
 
 #[dojo::contract]
 mod ERC20Bridgeable {
-    use token::erc20::interface;
     use integer::BoundedInt;
     use starknet::ContractAddress;
     use starknet::{get_caller_address, get_contract_address};


### PR DESCRIPTION
- Remove erc helper fn `emit_event` and inline it

- Update `emit!` calls ex:
`emit!(world, Moved { player, direction });` --> `emit!(world, (Event::Moved(Moved { player, direction })));`




