### PR TITLE
⬆️ Upgrade dojo to v0.7.0-alpha.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: Origami CI
 on: [push, pull_request]
 
 env:
-  DOJO_VERSION: v0.7.0-alpha.1
+  DOJO_VERSION: v0.7.0-alpha.2
   SCARB_VERSION: v2.6.4
 
 jobs:

--- a/Scarb.lock
+++ b/Scarb.lock
@@ -11,12 +11,12 @@ dependencies = [
 [[package]]
 name = "cubit"
 version = "1.3.0"
-source = "git+https://github.com/influenceth/cubit.git?rev=09cb8c2#09cb8c2af6c0216315e0a880fd7198381c7b911c"
+source = "git+https://github.com/influenceth/cubit.git?rev=8eacc2b#8eacc2b1d952d6266f9725776445c7fb97453403"
 
 [[package]]
 name = "dojo"
 version = "0.6.0"
-source = "git+https://github.com/dojoengine/dojo?tag=v0.7.0-alpha.1#d6c3080c7c41552323c86387fcb51c68de076ec4"
+source = "git+https://github.com/dojoengine/dojo?tag=v0.7.0-alpha.2#f648e870fc48d004e770559ab61a3a8537e4624c"
 dependencies = [
  "dojo_plugin",
 ]

--- a/Scarb.toml
+++ b/Scarb.toml
@@ -10,13 +10,13 @@ members = [
 ]
 
 [workspace.package]
-version = "0.6.0"
+version = "0.7.0-alpha.2"
 description = "Community-maintained libraries for Cairo"
 homepage = "https://github.com/dojoengine/origami"
 authors = ["bal7hazar@proton.me"]
 
 [workspace.dependencies]
-cubit = { git = "https://github.com/influenceth/cubit.git", rev = "09cb8c2" }
-dojo = { git = "https://github.com/dojoengine/dojo", tag = "v0.7.0-alpha.1" }
+cubit = { git = "https://github.com/influenceth/cubit.git", rev = "8eacc2b" }
+dojo = { git = "https://github.com/dojoengine/dojo", tag = "v0.7.0-alpha.2" }
 origami = { path = "crates" }
 token = { path = "token" }


### PR DESCRIPTION
Also upgraded the cubit version to the latest which remove a scarb warning.

@notV4l could you release a new origami version after the merge please?