### PR TITLE
Changed starknet::Storage to starknet::Store

### DIFF
--- a/crates/src/defi/auction/vrgda.cairo
+++ b/crates/src/defi/auction/vrgda.cairo
@@ -46,7 +46,7 @@ impl TVRGDATrait<T, +VRGDAVarsTrait<T>, +VRGDATargetTimeTrait<T>> of VRGDATrait<
 /// A Linear Variable Rate Gradual Dutch Auction (VRGDA) struct.
 /// Represents an auction where the price decays linearly based on the target price,
 /// decay constant, and per-time-unit rate.
-#[derive(Copy, Drop, Serde, starknet::Storage)]
+#[derive(Copy, Drop, Serde, starknet::Store)]
 struct LinearVRGDA {
     target_price: Fixed,
     decay_constant: Fixed,
@@ -81,7 +81,7 @@ impl LinearVRGDATargetTimeImpl of VRGDATargetTimeTrait<LinearVRGDA> {
 
 impl LinearVRGDAImpl = TVRGDATrait<LinearVRGDA>;
 
-#[derive(Copy, Drop, Serde, starknet::Storage)]
+#[derive(Copy, Drop, Serde, starknet::Store)]
 struct LogisticVRGDA {
     target_price: Fixed,
     decay_constant: Fixed,


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Closes #

## Introduced changes

<!-- A brief description of the changes -->

- starknet::Storage shoud have been starknet::Store to be able to be used in a Storage in a contract

## Checklist

<!-- Make sure all of these are complete -->

- [ ] Linked relevant issue
- [ ] Updated relevant documentation
- [ ] Added relevant tests
- [ ] Add a dedicated CI job for new examples
- [ ] Performed self-review of the code