### PR TITLE
update to v0.7.0-alpha.5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: Origami CI
 on: [push, pull_request]
 
 env:
-  DOJO_VERSION: v0.7.0-alpha.4
+  DOJO_VERSION: v0.7.0-alpha.5
   SCARB_VERSION: v2.6.4
 
 jobs:

--- a/Scarb.lock
+++ b/Scarb.lock
@@ -11,12 +11,12 @@ dependencies = [
 [[package]]
 name = "cubit"
 version = "1.3.0"
-source = "git+https://github.com/influenceth/cubit.git?rev=8eacc2b#8eacc2b1d952d6266f9725776445c7fb97453403"
+source = "git+https://github.com/influenceth/cubit.git#8eacc2b1d952d6266f9725776445c7fb97453403"
 
 [[package]]
 name = "dojo"
 version = "0.6.0"
-source = "git+https://github.com/dojoengine/dojo?tag=v0.7.0-alpha.4#aa5b534ebc4d82c18c6334ae7f3d236e77313c90"
+source = "git+https://github.com/dojoengine/dojo?tag=v0.7.0-alpha.5#328004d65bbbf7692c26f030b75fa95b7947841d"
 dependencies = [
  "dojo_plugin",
 ]
@@ -60,7 +60,7 @@ dependencies = [
 
 [[package]]
 name = "origami"
-version = "0.7.0-alpha.2"
+version = "0.7.0-alpha.5"
 dependencies = [
  "cubit",
  "dojo",

--- a/Scarb.toml
+++ b/Scarb.toml
@@ -11,13 +11,13 @@ members = [
 ]
 
 [workspace.package]
-version = "0.7.0-alpha.2"
+version = "0.7.0-alpha.5"
 description = "Community-maintained libraries for Cairo"
 homepage = "https://github.com/dojoengine/origami"
 authors = ["bal7hazar@proton.me"]
 
 [workspace.dependencies]
-cubit = { git = "https://github.com/influenceth/cubit.git", rev = "8eacc2b" }
-dojo = { git = "https://github.com/dojoengine/dojo", tag = "v0.7.0-alpha.4" }
+cubit = { git = "https://github.com/influenceth/cubit.git" }
+dojo = { git = "https://github.com/dojoengine/dojo", tag = "v0.7.0-alpha.5" }
 origami = { path = "crates" }
 token = { path = "token" }

--- a/examples/bridge/sn/src/tests/tests.cairo
+++ b/examples/bridge/sn/src/tests/tests.cairo
@@ -75,13 +75,13 @@ fn setup() -> (IWorldDispatcher, IDojoTokenDispatcher, IDojoBridgeDispatcher) {
     // deploy token
     let mut dojo_token_dispatcher = IDojoTokenDispatcher {
         contract_address: world
-            .deploy_contract('salt', dojo_token::TEST_CLASS_HASH.try_into().unwrap())
+            .deploy_contract('salt', dojo_token::TEST_CLASS_HASH.try_into().unwrap(), array![].span())
     };
 
      // deploy bridge
     let mut dojo_bridge_dispatcher = IDojoBridgeDispatcher {
         contract_address: world
-            .deploy_contract('salt', dojo_bridge::TEST_CLASS_HASH.try_into().unwrap())
+            .deploy_contract('salt', dojo_bridge::TEST_CLASS_HASH.try_into().unwrap(),array![].span())
     };
 
     // setup auth for dojo_token

--- a/examples/chess/src/tests/units.cairo
+++ b/examples/chess/src/tests/units.cairo
@@ -22,7 +22,7 @@ mod tests {
 
         // deploy systems contract
         let contract_address = world
-            .deploy_contract('salt', actions::TEST_CLASS_HASH.try_into().unwrap());
+            .deploy_contract('salt', actions::TEST_CLASS_HASH.try_into().unwrap(), array![].span());
         let actions_system = IActionsDispatcher { contract_address };
 
         (world, actions_system)

--- a/examples/hex_map/src/actions.cairo
+++ b/examples/hex_map/src/actions.cairo
@@ -119,7 +119,7 @@ mod tests {
 
         // deploy systems contract
         let contract_address = world
-            .deploy_contract('salt', actions::TEST_CLASS_HASH.try_into().unwrap());
+            .deploy_contract('salt', actions::TEST_CLASS_HASH.try_into().unwrap(), array![].span());
         let actions_system = IActionsDispatcher { contract_address };
 
         (world, actions_system)

--- a/governance/src/models/governor.cairo
+++ b/governance/src/models/governor.cairo
@@ -1,7 +1,8 @@
 use governance::libraries::traits::{ContractAddressDefault, ClassHashDefault};
 use starknet::{ContractAddress, ClassHash};
 
-#[derive(Model, Copy, Drop, Serde)]
+#[dojo::model]
+#[derive(Copy, Drop, Serde)]
 struct GovernorParams {
     #[key]
     contract: ContractAddress,
@@ -10,7 +11,8 @@ struct GovernorParams {
     guardian: ContractAddress,
 }
 
-#[derive(Model, Copy, Drop, Serde)]
+#[dojo::model]
+#[derive(Copy, Drop, Serde)]
 struct ProposalParams {
     #[key]
     contract: ContractAddress,
@@ -20,21 +22,24 @@ struct ProposalParams {
     voting_period: u64,
 }
 
-#[derive(Model, Copy, Drop, Serde)]
+#[dojo::model]
+#[derive(Copy, Drop, Serde)]
 struct ProposalCount {
     #[key]
     contract: ContractAddress,
     count: usize,
 }
 
-#[derive(Model, Copy, Drop, Serde)]
+#[dojo::model]
+#[derive(Copy, Drop, Serde)]
 struct Proposals {
     #[key]
     id: usize,
     proposal: Proposal,
 }
 
-#[derive(Model, Copy, Drop, Serde)]
+#[dojo::model]
+#[derive(Copy, Drop, Serde)]
 struct Receipts {
     #[key]
     proposal_id: usize,
@@ -43,7 +48,8 @@ struct Receipts {
     receipt: Receipt,
 }
 
-#[derive(Model, Copy, Drop, Serde)]
+#[dojo::model]
+#[derive(Copy, Drop, Serde)]
 struct LatestProposalIds {
     #[key]
     address: ContractAddress,

--- a/governance/src/models/timelock.cairo
+++ b/governance/src/models/timelock.cairo
@@ -1,6 +1,8 @@
 use starknet::{ContractAddress, ClassHash};
 
-#[derive(Model, Copy, Drop, Serde)]
+
+#[dojo::model]
+#[derive(Copy, Drop, Serde)]
 struct TimelockParams {
     #[key]
     contract: ContractAddress,
@@ -8,14 +10,16 @@ struct TimelockParams {
     delay: u64,
 }
 
-#[derive(Model, Copy, Drop, Serde)]
+#[dojo::model]
+#[derive(Copy, Drop, Serde)]
 struct PendingAdmin {
     #[key]
     contract: ContractAddress,
     address: ContractAddress,
 }
 
-#[derive(Model, Copy, Drop, Serde)]
+#[dojo::model]
+#[derive(Copy, Drop, Serde)]
 struct QueuedTransactions {
     #[key]
     contract: ContractAddress,

--- a/governance/src/models/token.cairo
+++ b/governance/src/models/token.cairo
@@ -1,6 +1,7 @@
 use starknet::ContractAddress;
 
-#[derive(Model, Copy, Drop, Serde)]
+#[dojo::model]
+#[derive(Copy, Drop, Serde)]
 struct Metadata {
     #[key]
     token: ContractAddress,
@@ -9,14 +10,16 @@ struct Metadata {
     decimals: u8,
 }
 
-#[derive(Model, Copy, Drop, Serde)]
+#[dojo::model]
+#[derive(Copy, Drop, Serde)]
 struct TotalSupply {
     #[key]
     token: ContractAddress,
     amount: u128,
 }
 
-#[derive(Model, Copy, Drop, Serde)]
+#[dojo::model]
+#[derive(Copy, Drop, Serde)]
 struct Allowances {
     #[key]
     delegator: ContractAddress,
@@ -25,21 +28,24 @@ struct Allowances {
     amount: u128,
 }
 
-#[derive(Model, Copy, Drop, Serde)]
+#[dojo::model]
+#[derive(Copy, Drop, Serde)]
 struct Balances {
     #[key]
     account: ContractAddress,
     amount: u128,
 }
 
-#[derive(Model, Copy, Drop, Serde)]
+#[dojo::model]
+#[derive(Copy, Drop, Serde)]
 struct Delegates {
     #[key]
     account: ContractAddress,
     address: ContractAddress,
 }
 
-#[derive(Model, Copy, Drop, Serde)]
+#[dojo::model]
+#[derive(Copy, Drop, Serde)]
 struct Checkpoints {
     #[key]
     account: ContractAddress,
@@ -48,14 +54,16 @@ struct Checkpoints {
     checkpoint: Checkpoint,
 }
 
-#[derive(Model, Copy, Drop, Serde)]
+#[dojo::model]
+#[derive(Copy, Drop, Serde)]
 struct NumCheckpoints {
     #[key]
     account: ContractAddress,
     count: u64,
 }
 
-#[derive(Model, Copy, Drop, Serde)]
+#[dojo::model]
+#[derive(Copy, Drop, Serde)]
 struct Nonces {
     #[key]
     account: ContractAddress,

--- a/governance/src/utils/mock_contract.cairo
+++ b/governance/src/utils/mock_contract.cairo
@@ -6,7 +6,8 @@ trait IHelloStarknet {
     fn get_balance() -> u128;
 }
 
-#[derive(Model, Copy, Drop, Serde)]
+#[dojo::model]
+#[derive(Copy, Drop, Serde)]
 struct MockBalances {
     #[key]
     account: u128,

--- a/governance/src/utils/mock_contract_upgraded.cairo
+++ b/governance/src/utils/mock_contract_upgraded.cairo
@@ -7,7 +7,8 @@ trait IHelloStarknetUgraded {
     fn get_balance() -> u128;
 }
 
-#[derive(Model, Copy, Drop, Serde)]
+#[dojo::model]
+#[derive(Copy, Drop, Serde)]
 struct MockBalances {
     #[key]
     account: u128,

--- a/governance/src/utils/testing.cairo
+++ b/governance/src/utils/testing.cairo
@@ -80,22 +80,25 @@ fn setup() -> (Systems, IWorldDispatcher) {
     ];
     let world = spawn_test_world(models);
 
-    let contract_address = world.deploy_contract(1, governor::TEST_CLASS_HASH.try_into().unwrap());
+    let contract_address = world
+        .deploy_contract(1, governor::TEST_CLASS_HASH.try_into().unwrap(), array![].span());
     let governor = IGovernorDispatcher { contract_address };
 
-    let contract_address = world.deploy_contract(2, timelock::TEST_CLASS_HASH.try_into().unwrap());
+    let contract_address = world
+        .deploy_contract(2, timelock::TEST_CLASS_HASH.try_into().unwrap(), array![].span());
     let timelock = ITimelockDispatcher { contract_address };
 
     let contract_address = world
-        .deploy_contract(3, governancetoken::TEST_CLASS_HASH.try_into().unwrap());
+        .deploy_contract(3, governancetoken::TEST_CLASS_HASH.try_into().unwrap(), array![].span());
     let token = IGovernanceTokenDispatcher { contract_address };
 
     let contract_address = world
-        .deploy_contract(4, hellostarknet::TEST_CLASS_HASH.try_into().unwrap());
+        .deploy_contract(4, hellostarknet::TEST_CLASS_HASH.try_into().unwrap(), array![].span());
     let mock = IHelloStarknetDispatcher { contract_address };
 
     let systems = Systems { governor, timelock, token, mock };
 
+    // should use constructor now
     systems.governor.initialize(timelock.contract_address, token.contract_address, GOVERNOR());
     systems.token.initialize('Gov Token', 'GOV', 18, INITIAL_SUPPLY, GOVERNOR());
     // systems.timelock.initialize(systems.governor.contract_address, DAY * 2);

--- a/token/src/components/tests/introspection/test_src5.cairo
+++ b/token/src/components/tests/introspection/test_src5.cairo
@@ -4,8 +4,7 @@ use dojo::test_utils::spawn_test_world;
 use token::components::introspection::src5::{src_5_model, SRC5Model, ISRC5, ISRC5_ID};
 use token::components::introspection::src5::src5_component::{InternalImpl};
 use token::components::tests::mocks::src5_mock::SRC5Mock;
-use token::components::tests::mocks::src5_mock::SRC5Mock::world_dispatcherContractMemberStateTrait;
-
+use starknet::storage::{StorageMemberAccessTrait};
 use token::tests::constants::{OTHER_ID};
 
 

--- a/token/src/components/tests/security/test_initializable.cairo
+++ b/token/src/components/tests/security/test_initializable.cairo
@@ -6,8 +6,7 @@ use token::components::security::initializable::initializable_component::{
     InitializableImpl, InternalImpl
 };
 use token::components::tests::mocks::initializable_mock::InitializableMock;
-use token::components::tests::mocks::initializable_mock::InitializableMock::world_dispatcherContractMemberStateTrait;
-
+use starknet::storage::{StorageMemberAccessTrait};
 
 fn STATE() -> (IWorldDispatcher, InitializableMock::ContractState) {
     let world = spawn_test_world(array![initializable_model::TEST_CLASS_HASH,]);

--- a/token/src/components/tests/token/erc20/test_erc20_allowance.cairo
+++ b/token/src/components/tests/token/erc20/test_erc20_allowance.cairo
@@ -15,8 +15,7 @@ use token::components::token::erc20::erc20_allowance::erc20_allowance_component:
     Approval, ERC20AllowanceImpl, InternalImpl
 };
 use token::components::tests::mocks::erc20::erc20_allowance_mock::erc20_allowance_mock;
-use token::components::tests::mocks::erc20::erc20_allowance_mock::erc20_allowance_mock::world_dispatcherContractMemberStateTrait;
-
+use starknet::storage::{StorageMemberAccessTrait};
 use debug::PrintTrait;
 
 //

--- a/token/src/components/tests/token/erc20/test_erc20_balance.cairo
+++ b/token/src/components/tests/token/erc20/test_erc20_balance.cairo
@@ -19,8 +19,7 @@ use token::components::token::erc20::erc20_balance::erc20_balance_component::{
 use token::components::tests::mocks::erc20::erc20_balance_mock::{
     erc20_balance_mock, IERC20BalanceMockDispatcher, IERC20BalanceMockDispatcherTrait
 };
-use token::components::tests::mocks::erc20::erc20_balance_mock::erc20_balance_mock::world_dispatcherContractMemberStateTrait;
-
+use starknet::storage::{StorageMemberAccessTrait};
 use token::components::tests::token::erc20::test_erc20_allowance::{
     assert_event_approval, assert_only_event_approval
 };
@@ -162,7 +161,9 @@ fn setup() -> (IWorldDispatcher, IERC20BalanceMockDispatcher) {
     // deploy contract
     let mut erc20_balance_mock_dispatcher = IERC20BalanceMockDispatcher {
         contract_address: world
-            .deploy_contract('salt', erc20_balance_mock::TEST_CLASS_HASH.try_into().unwrap())
+            .deploy_contract(
+                'salt', erc20_balance_mock::TEST_CLASS_HASH.try_into().unwrap(), array![].span()
+            )
     };
 
     // setup auth
@@ -175,6 +176,7 @@ fn setup() -> (IWorldDispatcher, IERC20BalanceMockDispatcher) {
             selector!("ERC20BalanceModel"), erc20_balance_mock_dispatcher.contract_address
         );
 
+    // should use constructor now
     // initialize contracts
     erc20_balance_mock_dispatcher.initializer(SUPPLY, OWNER());
 

--- a/token/src/components/tests/token/erc20/test_erc20_bridgeable.cairo
+++ b/token/src/components/tests/token/erc20/test_erc20_bridgeable.cairo
@@ -32,8 +32,7 @@ use token::components::tests::mocks::erc20::erc20_bridgeable_mock::erc20_bridgea
 use token::components::tests::mocks::erc20::erc20_bridgeable_mock::erc20_bridgeable_mock::{
     ERC20InitializerImpl
 };
-use token::components::tests::mocks::erc20::erc20_bridgeable_mock::erc20_bridgeable_mock::world_dispatcherContractMemberStateTrait;
-
+use starknet::storage::{StorageMemberAccessTrait};
 
 fn STATE() -> (IWorldDispatcher, erc20_bridgeable_mock::ContractState) {
     let world = spawn_test_world(

--- a/token/src/components/tests/token/erc20/test_erc20_metadata.cairo
+++ b/token/src/components/tests/token/erc20/test_erc20_metadata.cairo
@@ -8,8 +8,7 @@ use token::components::token::erc20::erc20_metadata::erc20_metadata_component::{
     ERC20MetadataImpl, ERC20MetadataTotalSupplyImpl, ERC20MetadataTotalSupplyCamelImpl, InternalImpl
 };
 use token::components::tests::mocks::erc20::erc20_metadata_mock::erc20_metadata_mock;
-use token::components::tests::mocks::erc20::erc20_metadata_mock::erc20_metadata_mock::world_dispatcherContractMemberStateTrait;
-
+use starknet::storage::{StorageMemberAccessTrait};
 
 fn STATE() -> (IWorldDispatcher, erc20_metadata_mock::ContractState) {
     let world = spawn_test_world(array![erc_20_metadata_model::TEST_CLASS_HASH,]);

--- a/token/src/components/tests/token/erc20/test_erc20_mintable_burnable.cairo
+++ b/token/src/components/tests/token/erc20/test_erc20_mintable_burnable.cairo
@@ -17,8 +17,7 @@ use token::components::token::erc20::erc20_mintable::erc20_mintable_component::I
 use token::components::token::erc20::erc20_burnable::erc20_burnable_component::InternalImpl as ERC20BurnableInternalImpl;
 
 use token::components::tests::mocks::erc20::erc20_mintable_burnable_mock::erc20_mintable_burnable_mock;
-use token::components::tests::mocks::erc20::erc20_mintable_burnable_mock::erc20_mintable_burnable_mock::world_dispatcherContractMemberStateTrait;
-
+use starknet::storage::{StorageMemberAccessTrait};
 
 fn STATE() -> (IWorldDispatcher, erc20_mintable_burnable_mock::ContractState) {
     let world = spawn_test_world(

--- a/token/src/erc1155/tests.cairo
+++ b/token/src/erc1155/tests.cairo
@@ -22,7 +22,8 @@ use token::erc1155::models::{
     ERC1155Meta, erc_1155_meta, ERC1155OperatorApproval, erc_1155_operator_approval, ERC1155Balance,
     erc_1155_balance
 };
-use token::erc1155::ERC1155::_worldContractMemberStateTrait;
+use starknet::storage::{StorageMemberAccessTrait};
+
 use debug::PrintTrait;
 
 //

--- a/token/src/erc20/tests.cairo
+++ b/token/src/erc20/tests.cairo
@@ -21,7 +21,8 @@ use dojo::world::{IWorldDispatcher, IWorldDispatcherTrait};
 use token::erc20::models::{
     ERC20Allowance, erc_20_allowance, ERC20Balance, erc_20_balance, ERC20Meta, erc_20_meta
 };
-use token::erc20::ERC20::_worldContractMemberStateTrait;
+use starknet::storage::{StorageMemberAccessTrait};
+
 use debug::PrintTrait;
 
 //

--- a/token/src/erc721/tests.cairo
+++ b/token/src/erc721/tests.cairo
@@ -35,7 +35,8 @@ use token::erc721::models::{
     ERC721Meta, erc_721_meta, ERC721OperatorApproval, erc_721_operator_approval, ERC721Owner,
     erc_721_owner, ERC721Balance, erc_721_balance, ERC721TokenApproval, erc_721_token_approval
 };
-use token::erc721::ERC721::_worldContractMemberStateTrait;
+use starknet::storage::{StorageMemberAccessTrait};
+
 
 //
 // Setup

--- a/token/src/presets/erc20/tests_bridgeable.cairo
+++ b/token/src/presets/erc20/tests_bridgeable.cairo
@@ -43,7 +43,7 @@ use token::presets::erc20::bridgeable::{
     ERC20Bridgeable, IERC20BridgeablePresetDispatcher, IERC20BridgeablePresetDispatcherTrait
 };
 use token::presets::erc20::bridgeable::ERC20Bridgeable::{ERC20InitializerImpl};
-use token::presets::erc20::bridgeable::ERC20Bridgeable::world_dispatcherContractMemberStateTrait;
+use starknet::storage::{StorageMemberAccessTrait};
 
 use token::components::tests::token::erc20::test_erc20_allowance::{
     assert_event_approval, assert_only_event_approval
@@ -70,7 +70,9 @@ fn setup() -> (IWorldDispatcher, IERC20BridgeablePresetDispatcher) {
     // deploy contract
     let mut erc20_bridgeable_dispatcher = IERC20BridgeablePresetDispatcher {
         contract_address: world
-            .deploy_contract('salt', ERC20Bridgeable::TEST_CLASS_HASH.try_into().unwrap())
+            .deploy_contract(
+                'salt', ERC20Bridgeable::TEST_CLASS_HASH.try_into().unwrap(), array![].span()
+            )
     };
 
     // setup auth


### PR DESCRIPTION
- update to dojo v0.7.0-alpha.5
- update gouvernance models to use `#[dojo::model]`
- add empty calldata to `deploy_contract(` calls ( this should be updated to use constructor calldata in some cases)
- remove all `world_dispatcherContractMemberStateTrait` references & `use starknet::storage::{StorageMemberAccessTrait};`