### PR TITLE
ERC-721 Metadata hook

### DIFF
--- a/token/src/components/tests.cairo
+++ b/token/src/components/tests.cairo
@@ -15,6 +15,7 @@ mod mocks {
         mod erc721_balance_mock;
         mod erc721_enumerable_mock;
         mod erc721_metadata_mock;
+        mod erc721_metadata_hooks_mock;
         mod erc721_mintable_burnable_mock;
         mod erc721_receiver_mock;
     }
@@ -54,6 +55,8 @@ mod token {
         mod test_erc721_enumerable;
         #[cfg(test)]
         mod test_erc721_metadata;
+        #[cfg(test)]
+        mod test_erc721_metadata_hooks;
         #[cfg(test)]
         mod test_erc721_mintable_burnable;
     }

--- a/token/src/components/tests/mocks/erc721/erc721_metadata_hooks_mock.cairo
+++ b/token/src/components/tests/mocks/erc721/erc721_metadata_hooks_mock.cairo
@@ -1,9 +1,19 @@
+use dojo::world::IWorldDispatcher;
+
+#[starknet::interface]
+// trait IERC721EnumMintBurnPreset {
+trait IERC721MetadataHooksMock<TContractState> {
+    // IWorldProvider
+    fn world(self: @TContractState,) -> IWorldDispatcher;
+}
+
 #[dojo::contract]
-mod erc721_metadata_mock {
+mod erc721_metadata_hooks_mock {
+
+    use starknet::{get_contract_address};
     use token::components::token::erc721::erc721_approval::erc721_approval_component;
     use token::components::token::erc721::erc721_balance::erc721_balance_component;
     use token::components::token::erc721::erc721_metadata::erc721_metadata_component;
-    use token::components::token::erc721::erc721_metadata_hooks::ERC721MetadataHooksEmptyImpl;
     use token::components::token::erc721::erc721_mintable::erc721_mintable_component;
     use token::components::token::erc721::erc721_owner::erc721_owner_component;
 
@@ -51,5 +61,28 @@ mod erc721_metadata_mock {
         ERC721MetadataEvent: erc721_metadata_component::Event,
         ERC721MintableEvent: erc721_mintable_component::Event,
         ERC721OwnerEvent: erc721_owner_component::Event
+    }
+
+    
+    //
+    // Metadata Hooks
+    //
+    use super::{IERC721MetadataHooksMockDispatcher, IERC721MetadataHooksMockDispatcherTrait};
+    impl ERC721MetadataHooksImpl<TContractState> of erc721_metadata_component::ERC721MetadataHooksTrait<TContractState> {
+        fn custom_uri(
+            self: @erc721_metadata_component::ComponentState<TContractState>,
+            base_uri: @ByteArray,
+            token_id: u256,
+        ) -> ByteArray {
+            //
+            // example on how to access the world
+            // (does not work for testing, throws 'CONTRACT_NOT_DEPLOYED')
+            //
+            // let contract_address = get_contract_address();
+            // let selfie = IERC721MetadataHooksMockDispatcher{ contract_address };
+            // let _world = selfie.world();
+
+            format!("CUSTOM{}{}", base_uri, token_id)
+        }
     }
 }

--- a/token/src/components/tests/mocks/erc721/erc721_mintable_burnable_mock.cairo
+++ b/token/src/components/tests/mocks/erc721/erc721_mintable_burnable_mock.cairo
@@ -3,6 +3,7 @@ mod erc721_mintable_burnable_mock {
     use token::components::token::erc721::erc721_approval::erc721_approval_component;
     use token::components::token::erc721::erc721_balance::erc721_balance_component;
     use token::components::token::erc721::erc721_metadata::erc721_metadata_component;
+    use token::components::token::erc721::erc721_metadata_hooks::ERC721MetadataHooksEmptyImpl;
     use token::components::token::erc721::erc721_mintable::erc721_mintable_component;
     use token::components::token::erc721::erc721_burnable::erc721_burnable_component;
     use token::components::token::erc721::erc721_owner::erc721_owner_component;

--- a/token/src/components/tests/token/erc721/test_erc721_metadata_hooks.cairo
+++ b/token/src/components/tests/token/erc721/test_erc721_metadata_hooks.cairo
@@ -1,0 +1,41 @@
+use integer::BoundedInt;
+use dojo::world::{IWorldDispatcher, IWorldDispatcherTrait};
+use dojo::test_utils::spawn_test_world;
+use token::tests::constants::{OWNER};
+
+use token::components::token::erc721::erc721_metadata::{erc_721_meta_model, ERC721MetaModel,};
+use token::components::token::erc721::erc721_metadata::erc721_metadata_component::{
+    ERC721MetadataImpl, ERC721MetadataCamelImpl, InternalImpl
+};
+use token::components::token::erc721::erc721_mintable::erc721_mintable_component::InternalImpl as ERC721MintableInternalImpl;
+
+use token::components::tests::mocks::erc721::erc721_metadata_hooks_mock::erc721_metadata_hooks_mock;
+use starknet::storage::{StorageMemberAccessTrait};
+
+
+fn STATE() -> (IWorldDispatcher, erc721_metadata_hooks_mock::ContractState) {
+    let world = spawn_test_world(array![erc_721_meta_model::TEST_CLASS_HASH,]);
+
+    let mut state = erc721_metadata_hooks_mock::contract_state_for_testing();
+    state.world_dispatcher.write(world);
+
+    (world, state)
+}
+
+#[test]
+fn test_erc721_metadata_hooks_initialize() {
+    let (_world, mut state) = STATE();
+
+    let NAME: ByteArray = "NAME";
+    let SYMBOL: ByteArray = "SYMBOL";
+    let URI: ByteArray = "URI";
+
+    state.erc721_metadata.initialize(NAME, SYMBOL, URI);
+
+    assert(state.erc721_metadata.name() == "NAME", 'Should be NAME');
+    assert(state.erc721_metadata.symbol() == "SYMBOL", 'Should be SYMBOL');
+
+    state.erc721_mintable.mint(OWNER(), 1);
+    assert(state.erc721_metadata.token_uri(1) == "CUSTOMURI1", 'Should be CUSTOMURI1');
+    assert(state.erc721_metadata.tokenURI(1) == "CUSTOMURI1", 'Should be CUSTOMURI1');
+}

--- a/token/src/components/token/erc721/erc721_metadata.cairo
+++ b/token/src/components/token/erc721/erc721_metadata.cairo
@@ -22,16 +22,16 @@ struct ERC721MetaModel {
 trait IERC721Metadata<TState> {
     fn name(self: @TState) -> ByteArray;
     fn symbol(self: @TState) -> ByteArray;
-    fn token_uri(ref self: TState, token_id: u256) -> ByteArray;
+    fn token_uri(self: @TState, token_id: u256) -> ByteArray;
 }
 
 #[starknet::interface]
 trait IERC721MetadataCamel<TState> {
-    fn tokenURI(ref self: TState, tokenId: u256) -> ByteArray;
+    fn tokenURI(self: @TState, tokenId: u256) -> ByteArray;
 }
 
 ///
-/// ERC20Metadata Component
+/// ERC721Metadata Component
 ///
 #[starknet::component]
 mod erc721_metadata_component {
@@ -68,7 +68,7 @@ mod erc721_metadata_component {
         fn symbol(self: @ComponentState<TContractState>) -> ByteArray {
             self.get_meta().symbol
         }
-        fn token_uri(ref self: ComponentState<TContractState>, token_id: u256) -> ByteArray {
+        fn token_uri(self: @ComponentState<TContractState>, token_id: u256) -> ByteArray {
             self.get_uri(token_id)
         }
     }
@@ -81,7 +81,7 @@ mod erc721_metadata_component {
         impl ERC721Owner: erc721_owner_comp::HasComponent<TContractState>,
         +Drop<TContractState>,
     > of IERC721MetadataCamel<ComponentState<TContractState>> {
-        fn tokenURI(ref self: ComponentState<TContractState>, tokenId: u256) -> ByteArray {
+        fn tokenURI(self: @ComponentState<TContractState>, tokenId: u256) -> ByteArray {
             self.get_uri(tokenId)
         }
     }
@@ -99,8 +99,8 @@ mod erc721_metadata_component {
             get!(self.get_contract().world(), get_contract_address(), (ERC721MetaModel))
         }
 
-        fn get_uri(ref self: ComponentState<TContractState>, token_id: u256) -> ByteArray {
-            let mut erc721_owner = get_dep_component_mut!(ref self, ERC721Owner);
+        fn get_uri(self: @ComponentState<TContractState>, token_id: u256) -> ByteArray {
+            let mut erc721_owner = get_dep_component!(self, ERC721Owner);
             assert(erc721_owner.exists(token_id), Errors::INVALID_TOKEN_ID);
             let base_uri = self.get_meta().base_uri;
             if base_uri.len() == 0 {

--- a/token/src/components/token/erc721/erc721_metadata_hooks.cairo
+++ b/token/src/components/token/erc721/erc721_metadata_hooks.cairo
@@ -1,0 +1,20 @@
+
+/// 
+/// An empty implementation of the ERC721MetadataHooksTrait
+/// 
+/// When the hook is not required, import together with the component:
+/// use token::components::token::erc721::erc721_metadata::erc721_metadata_component;
+/// use token::components::token::erc721::erc721_metadata_hooks::ERC721MetadataHooksEmptyImpl;
+/// 
+/// Or implement your own (example on erc721_metadata_hooks_mock.cairo)
+/// 
+
+use token::components::token::erc721::erc721_metadata::erc721_metadata_component;
+
+impl ERC721MetadataHooksEmptyImpl<TContractState> of erc721_metadata_component::ERC721MetadataHooksTrait<TContractState> {
+    fn custom_uri(
+        self: @erc721_metadata_component::ComponentState<TContractState>,
+        base_uri: @ByteArray,
+        token_id: u256,
+    ) -> ByteArray { "" }
+}

--- a/token/src/lib.cairo
+++ b/token/src/lib.cairo
@@ -23,6 +23,7 @@ mod components {
             mod erc721_burnable;
             mod erc721_enumerable;
             mod erc721_metadata;
+            mod erc721_metadata_hooks;
             mod erc721_mintable;
             mod erc721_owner;
             mod erc721_receiver;

--- a/token/src/presets/erc721/enumerable_mintable_burnable.cairo
+++ b/token/src/presets/erc721/enumerable_mintable_burnable.cairo
@@ -6,7 +6,7 @@ trait IERC721EnumMintBurnPreset<TState> {
     // IERC721
     fn name(self: @TState) -> ByteArray;
     fn symbol(self: @TState) -> ByteArray;
-    fn token_uri(ref self: TState, token_id: u256) -> ByteArray;
+    fn token_uri(self: @TState, token_id: u256) -> ByteArray;
     fn owner_of(self: @TState, account: ContractAddress) -> bool;
     fn get_approved(self: @TState, token_id: u256) -> ContractAddress;
     fn approve(ref self: TState, to: ContractAddress, token_id: u256);
@@ -15,7 +15,7 @@ trait IERC721EnumMintBurnPreset<TState> {
     fn token_of_owner_by_index(self: @TState, owner: ContractAddress, index: u256) -> u256;
 
     // IERC721CamelOnly
-    fn tokenURI(ref self: TState, token_id: u256) -> ByteArray;
+    fn tokenURI(self: @TState, token_id: u256) -> ByteArray;
 
     // IWorldProvider
     fn world(self: @TState,) -> IWorldDispatcher;

--- a/token/src/presets/erc721/enumerable_mintable_burnable.cairo
+++ b/token/src/presets/erc721/enumerable_mintable_burnable.cairo
@@ -82,6 +82,7 @@ mod ERC721EnumMintBurn {
     use token::components::token::erc721::erc721_burnable::erc721_burnable_component;
     use token::components::token::erc721::erc721_enumerable::erc721_enumerable_component;
     use token::components::token::erc721::erc721_metadata::erc721_metadata_component;
+    use token::components::token::erc721::erc721_metadata_hooks::ERC721MetadataHooksEmptyImpl;
     use token::components::token::erc721::erc721_mintable::erc721_mintable_component;
     use token::components::token::erc721::erc721_owner::erc721_owner_component;
 

--- a/token/src/presets/erc721/mintable_burnable.cairo
+++ b/token/src/presets/erc721/mintable_burnable.cairo
@@ -61,6 +61,7 @@ mod ERC721MintableBurnable {
     use token::components::token::erc721::erc721_balance::erc721_balance_component;
     use token::components::token::erc721::erc721_burnable::erc721_burnable_component;
     use token::components::token::erc721::erc721_metadata::erc721_metadata_component;
+    use token::components::token::erc721::erc721_metadata_hooks::ERC721MetadataHooksEmptyImpl;
     use token::components::token::erc721::erc721_mintable::erc721_mintable_component;
     use token::components::token::erc721::erc721_owner::erc721_owner_component;
 

--- a/token/src/presets/erc721/mintable_burnable.cairo
+++ b/token/src/presets/erc721/mintable_burnable.cairo
@@ -6,7 +6,7 @@ trait IERC721MintableBurnablePreset<TState> {
     // IERC721
     fn name(self: @TState) -> ByteArray;
     fn symbol(self: @TState) -> ByteArray;
-    fn token_uri(ref self: TState, token_id: u256) -> ByteArray;
+    fn token_uri(self: @TState, token_id: u256) -> ByteArray;
     fn owner_of(self: @TState, account: ContractAddress) -> bool;
     fn balance_of(self: @TState, account: ContractAddress) -> u256;
     fn get_approved(self: @TState, token_id: u256) -> ContractAddress;
@@ -14,7 +14,7 @@ trait IERC721MintableBurnablePreset<TState> {
     fn approve(ref self: TState, to: ContractAddress, token_id: u256);
 
     // IERC721CamelOnly
-    fn tokenURI(ref self: TState, token_id: u256) -> ByteArray;
+    fn tokenURI(self: @TState, token_id: u256) -> ByteArray;
     fn balanceOf(self: @TState, account: ContractAddress) -> u256;
     fn transferFrom(ref self: TState, from: ContractAddress, to: ContractAddress, token_id: u256);
 


### PR DESCRIPTION
Closes #79

## Introduced changes

* Changed `token_uri()` mutability to `view`
* Created `ERC721MetadataHooksTrait` containting single function `custom_uri()`
* Calling `custom_uri()` internally by `erc721_metadata_component::token_uri()`.
* Working implementation: 
https://github.com/rsodre/512karat/blob/main/dojo/src/systems/karat_token.cairo#L271-L287

## Breaking changes

Contracts that do not implement this hook are required to import `ERC721MetadataHooksEmptyImpl`.

```rust
use token::components::token::erc721::erc721_metadata::erc721_metadata_component;
use token::components::token::erc721::erc721_metadata_hooks::ERC721MetadataHooksEmptyImpl;
```

## Checklist

<!-- Make sure all of these are complete -->

- [x] Linked relevant issue
- [ ] Updated relevant documentation
- [x] Updated relevant **presets**
- [x] Added relevant tests
- [ ] Add a dedicated CI job for new examples
- [x] Performed self-review of the code